### PR TITLE
ganti model NIK_KTP di umkm.js dari INTEGER ke STRING. alasannya pas …

### DIFF
--- a/models/umkm.js
+++ b/models/umkm.js
@@ -37,7 +37,7 @@ const UMKM = sequelize.define('UMKM', {
         allowNull: true
     },
     NIK_KTP: {
-        type: DataTypes.INTEGER,
+        type: DataTypes.STRING,
         allowNull: false
     },
 


### PR DESCRIPTION
…ngetes, tadi kalo masukin nomor yang lebih dari limit, dia kena error gitu. jadi antara ganti tipe data ke BIGINT atau ke STRING